### PR TITLE
Test all nondeterministic result

### DIFF
--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -168,8 +168,12 @@ def test_set_serialize_function():
 
 
 def test_str():
-    assert str(Problem(400)) == "{'status': 400, 'title': 'Bad Request'}"
+    actual = str(Problem(400))
+    assert actual == "{'status': 400, 'title': 'Bad Request'}" or \
+        actual == "{'title': 'Bad Request', 'status': 400}"
 
 
 def test_repr():
-    assert repr(Problem(400)) == "{'status': 400, 'title': 'Bad Request'}"
+    actual = repr(Problem(400))
+    assert actual == "{'status': 400, 'title': 'Bad Request'}" or \
+        actual == "{'title': 'Bad Request', 'status': 400}"


### PR DESCRIPTION
Since `dict` → `str` conversion is nondeterministic, There are no order between dict keyss to make str.
So, It may occur fail of CI ocassionally. ( In fact, https://travis-ci.org/github/cbornet/python-httpproblem/builds/340516559 failed now).

If `actual` could be complicate dictionary, comparing `eval(actual)` with `{'status': 400, 'title': 'Bad Request'}` is more good solution to fix this problem.